### PR TITLE
Fix googleapiclient import error in google_client_integration_test.py

### DIFF
--- a/engine/utils/test/google_client_integration_test.py
+++ b/engine/utils/test/google_client_integration_test.py
@@ -9,6 +9,8 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
 
 from engine.utils.google_client import GoogleClient
 
+# Import googleapiclient module to ensure it is available
+import googleapiclient.discovery
 
 class TestGoogleClient(unittest.TestCase):
     current_script = os.path.abspath(__file__)


### PR DESCRIPTION
Add import statement for `googleapiclient` module in `google_client_integration_test.py`.

* Add a comment indicating the purpose of the import statement.
* Import `googleapiclient.discovery` to ensure the module is available.

